### PR TITLE
117 admin drawer

### DIFF
--- a/src/components/admin/Drawer.vue
+++ b/src/components/admin/Drawer.vue
@@ -1,7 +1,6 @@
 <template>
     <q-drawer
         v-model="showDrawer"
-        :show-if-above="desktopDrawer"
         :overlay="mobileDrawer"
         :width="300"
         :breakpoint="400"
@@ -76,13 +75,7 @@ export default {
         }
     },
     beforeMount() {
-        if (this.$q.platform.is.desktop) {
-            this.desktopDrawer = true
-            this.mobileDrawer = false
-        } else {
-            this.desktopDrawer = false
-            this.mobileDrawer = true
-        }
+        if (this.$q.platform.is.mobile) this.mobileDrawer = true
     },
 }
 </script>

--- a/src/layouts/AdminPage.vue
+++ b/src/layouts/AdminPage.vue
@@ -25,7 +25,7 @@ import Drawer from '@/components/admin/Drawer'
 export default {
     data() {
         return {
-            drawer: false,
+            drawer: true,
         }
     },
     methods: {
@@ -41,6 +41,9 @@ export default {
                     console.log(error)
                 })
         },
+    },
+    beforeMount() {
+        if (this.$q.platform.is.mobile) this.drawer = false
     },
     components: {
         'admin-navbar': Navbar,


### PR DESCRIPTION
**Closes**
#117 

**What to test**
Que el drawer en admin ya no tira el warning de modificar un prop desde el hijo.

**How to test**
- [ ] Acceder a admin y verficar en consola que el warning no vuelva a salir