### PR TITLE
brewing house approval

### DIFF
--- a/src/components/admin/PendingAccountsTable.vue
+++ b/src/components/admin/PendingAccountsTable.vue
@@ -11,7 +11,12 @@
         <template v-slot:header="props">
             <q-tr :props="props">
                 <q-th auto-width />
-                <q-th v-for="col in props.cols" :key="col.name" :props="props">{{ col.label }}</q-th>
+                <q-th
+                    v-for="col in props.cols"
+                    :key="col.name"
+                    :props="props"
+                    >{{ col.label }}</q-th
+                >
             </q-tr>
         </template>
 
@@ -35,11 +40,19 @@
                     >{{ col.value }}</q-td
                 >-->
                 <q-td :prop="props">{{ props.row.restaurantName }}</q-td>
+                <q-td :prop="props">{{ props.row.role }}</q-td>
                 <q-td :prop="props">{{ props.row.email }}</q-td>
                 <q-td :prop="props">
                     <q-badge
-                        :color="props.row.status == 'pending' ? 'warning' : 'red-7'"
-                    >{{ props.row.status == 'pending' ? 'Pendiente' : 'Rechazado' }}</q-badge>
+                        :color="
+                            props.row.status == 'pending' ? 'warning' : 'red-7'
+                        "
+                        >{{
+                            props.row.status == 'pending'
+                                ? 'Pendiente'
+                                : 'Rechazado'
+                        }}</q-badge
+                    >
                 </q-td>
             </q-tr>
         </template>
@@ -63,9 +76,17 @@ export default {
             columns: [
                 {
                     name: 'restaurantName',
-                    label: 'Restaurante',
+                    label: 'Comercio',
                     align: 'left',
                     field: 'restaurantName',
+                    sortable: true,
+                },
+
+                {
+                    name: 'accountType',
+                    label: 'Tipo de cuenta',
+                    align: 'left',
+                    field: 'accountType',
                     sortable: true,
                 },
 

--- a/src/views/admin/AccountDetails.vue
+++ b/src/views/admin/AccountDetails.vue
@@ -15,8 +15,16 @@
                     <div class="row q-mb-md">
                         <q-input
                             filled
-                            label="Nombre del restaurante"
+                            label="Nombre del comercio"
                             :value="data.restaurantName"
+                            class="q-mb-md full-width"
+                            dark
+                            readonly
+                        />
+                        <q-input
+                            filled
+                            label="Tipo de cuenta"
+                            :value="data.role"
                             class="q-mb-md full-width"
                             dark
                             readonly
@@ -113,9 +121,17 @@
                         :markers="[{position: data.location}]"
                         :mapCenter="data.location"
                     ></GoogleMaps>
-
                     <div class="row">
-                        <q-space />
+                        <q-select
+                            :options="['Casa Bruja', 'Central', 'Rana Dorada']"
+                            label="Seleccione casa cervecera a enlazar"
+                            class="full-width q-mb-md"
+                            v-model="linkBrewingHouse"
+                            dark
+                            filled
+                        />
+                    </div>
+                    <div class="row">
                         <q-btn
                             v-if="data.status != 'approved'"
                             color="secondary"
@@ -183,6 +199,7 @@ export default {
             rejectDialog: false,
             group: [],
             data: '',
+            linkBrewingHouse: '',
             options: [
                 {
                     label: 'No representa un comercio',


### PR DESCRIPTION
**Issue**
#221 

**What to test**
Se hicieron ajustes a la vista de /accounts-manager y /account-details para manejar la aprobacion de cuentas de casas cerveceras.

**How to test**
- [x] La tabla de cuentas por aprobar ahora muestra una columna de tipo de cuenta
- [x] En detalles de cuenta, hay un nuevo campo que muestra el tipo de cuenta
- [x] Se agrego un select para enlazar la cuenta con una casa cervecera existente

**Screenshots**

![image](https://user-images.githubusercontent.com/13292756/100641386-678bcb80-3305-11eb-92ee-7aa44fea0681.png)

![image](https://user-images.githubusercontent.com/13292756/100641425-72466080-3305-11eb-8f00-b23150b4809e.png)
